### PR TITLE
fix: GetPromptResults should be compatible with the actual schema

### DIFF
--- a/phpstan-baseline.php
+++ b/phpstan-baseline.php
@@ -452,6 +452,12 @@ $ignoreErrors[] = [
 	'path' => __DIR__ . '/src/Results/ResultInterface.php',
 ];
 $ignoreErrors[] = [
+	'message' => '#^Match arm comparison between \'resource\' and \'resource\' is always true\\.$#',
+	'identifier' => 'match.alwaysTrue',
+	'count' => 1,
+	'path' => __DIR__ . '/src/Schema/PromptMessage.php',
+];
+$ignoreErrors[] = [
 	'message' => '#^Parameter \\#1 \\$data of static method Swis\\\\McpClient\\\\Schema\\\\ToolAnnotation\\:\\:fromArray\\(\\) expects array\\{destructiveHint\\?\\: bool, idempotentHint\\?\\: bool, openWorldHint\\?\\: bool, readOnlyHint\\?\\: bool, title\\?\\: string\\}, array\\<string, mixed\\> given\\.$#',
 	'identifier' => 'argument.type',
 	'count' => 1,

--- a/src/Results/GetPromptResult.php
+++ b/src/Results/GetPromptResult.php
@@ -2,21 +2,19 @@
 
 namespace Swis\McpClient\Results;
 
-use Swis\McpClient\Exceptions\UnknownContentTypeException;
-use Swis\McpClient\Schema\Content\EmbeddedResource;
-use Swis\McpClient\Schema\Content\ImageContent;
-use Swis\McpClient\Schema\Content\TextContent;
+use Swis\McpClient\Schema\PromptMessage;
 
 /**
  * DTO for the get prompt result
  *
- * @phpstan-type GetPromptResultData array{description: string|null, messages: array{}, _meta?: array{}}
+ * @phpstan-import-type PromptMessageData from \Swis\McpClient\Schema\PromptMessage
+ * @phpstan-type GetPromptResultData array{description: string|null, messages: array<PromptMessageData>, _meta?: array{}}
  */
 class GetPromptResult extends BaseResult
 {
     /**
      * @param string $requestId The request ID this result is for
-     * @param array<TextContent|ImageContent|EmbeddedResource> $messages The message of the prompt
+     * @param array<PromptMessage> $messages The messages of the prompt
      * @param string|null $description The description of the prompt
      * @param array{}|null $meta Optional metadata
      */
@@ -47,7 +45,7 @@ class GetPromptResult extends BaseResult
     /**
      * Get messages
      *
-     * @return array<TextContent|ImageContent|EmbeddedResource>
+     * @return array<PromptMessage>
      */
     public function getMessages(): array
     {
@@ -73,17 +71,12 @@ class GetPromptResult extends BaseResult
      */
     public static function fromArray(array $data, string $requestId): self
     {
-        $messages = array_map(fn (array $messageData) => match ($messageData['type']) {
-            'text' => TextContent::fromArray($messageData),
-            'image' => ImageContent::fromArray($messageData),
-            'resource' => EmbeddedResource::fromArray($messageData),
-            default => throw new UnknownContentTypeException('Unknown message type: ' . $messageData['type'])
-        }, $data['messages']);
+        $messages = array_map(fn (array $messageData) => PromptMessage::fromArray($messageData), $data['messages']);
 
         return new self(
             $requestId,
             $messages,
-            $data['description'],
+            $data['description'] ?? null,
             $data['_meta'] ?? null
         );
     }

--- a/src/Schema/PromptMessage.php
+++ b/src/Schema/PromptMessage.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace Swis\McpClient\Schema;
+
+use Swis\McpClient\Exceptions\UnknownContentTypeException;
+use Swis\McpClient\Schema\Content\EmbeddedResource;
+use Swis\McpClient\Schema\Content\ImageContent;
+use Swis\McpClient\Schema\Content\TextContent;
+
+/**
+ * Represents a prompt message in the MCP schema
+ *
+ * @phpstan-import-type TextContentData from \Swis\McpClient\Schema\Content\TextContent
+ * @phpstan-import-type ImageContentData from \Swis\McpClient\Schema\Content\ImageContent
+ * @phpstan-import-type EmbeddedResourceData from \Swis\McpClient\Schema\Content\EmbeddedResource
+ * @phpstan-type PromptMessageData array{role: 'assistant'|'user', content: TextContentData|ImageContentData|EmbeddedResourceData}
+ */
+class PromptMessage
+{
+    /**
+     * @param Role $role Describes the role of the resource (e.g., "user", "assistant")
+     * @param TextContent|ImageContent|EmbeddedResource $content The content of the resource
+     */
+    public function __construct(
+        protected Role $role,
+        protected TextContent|ImageContent|EmbeddedResource $content,
+    ) {
+    }
+
+    /**
+     * Get the role of the message
+     *
+     * @return Role
+     */
+    public function getRole(): Role
+    {
+        return $this->role;
+    }
+
+    /**
+     * Get the content of the message
+     *
+     * @return TextContent|ImageContent|EmbeddedResource
+     */
+    public function getUri(): TextContent|ImageContent|EmbeddedResource
+    {
+        return $this->content;
+    }
+
+    /**
+     * Convert to array
+     *
+     * @return PromptMessageData
+     */
+    public function toArray(): array
+    {
+        return [
+            'role' => $this->role->value,
+            'content' => $this->content->toArray(),
+        ];
+    }
+
+    /**
+     * Create from array
+     *
+     * @param PromptMessageData $data
+     * @return self
+     */
+    public static function fromArray(array $data): self
+    {
+        $content = match ($data['content']['type']) {
+            'text' => TextContent::fromArray($data['content']),
+            'image' => ImageContent::fromArray($data['content']),
+            'resource' => EmbeddedResource::fromArray($data['content']),
+            default => throw new UnknownContentTypeException('Unknown content type: ' . $data['content']['type'])
+        };
+
+        return new self(
+            Role::from($data['role']),
+            $content
+        );
+    }
+}

--- a/tests/Results/GetPromptResultTest.php
+++ b/tests/Results/GetPromptResultTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace Swis\McpClient\Tests\Results;
+
+use PHPUnit\Framework\TestCase;
+use Swis\McpClient\Results\GetPromptResult;
+use Swis\McpClient\Schema\Content\TextContent;
+use Swis\McpClient\Schema\PromptMessage;
+use Swis\McpClient\Schema\Role;
+
+class GetPromptResultTest extends TestCase
+{
+    /**
+     * Test creating GetPromptResult from array
+     */
+    public function testFromArray(): void
+    {
+        $requestId = 'test-request-123';
+        $description = 'Test prompt description';
+        $messageData = [
+            'role' => 'user',
+            'content' => [
+                'type' => 'text',
+                'text' => 'This is a test message',
+            ],
+        ];
+
+        $data = [
+            'description' => $description,
+            'messages' => [$messageData],
+            '_meta' => ['test' => true],
+        ];
+
+        $result = GetPromptResult::fromArray($data, $requestId);
+
+        // Test basic properties
+        $this->assertEquals($requestId, $result->getRequestId());
+        $this->assertEquals($description, $result->getDescription());
+        $this->assertEquals(['test' => true], $result->getMeta());
+
+        // Test messages
+        $messages = $result->getMessages();
+        $this->assertCount(1, $messages);
+        $this->assertInstanceOf(PromptMessage::class, $messages[0]);
+        $this->assertEquals(Role::USER, $messages[0]->getRole());
+
+        $content = $messages[0]->getUri();
+        $this->assertInstanceOf(TextContent::class, $content);
+        $this->assertEquals('This is a test message', $content->getText());
+    }
+
+    /**
+     * Test creating GetPromptResult from array with multiple messages
+     */
+    public function testFromArrayWithMultipleMessages(): void
+    {
+        $requestId = 'test-request-456';
+        $description = 'Test with multiple messages';
+
+        $userMessageData = [
+            'role' => 'user',
+            'content' => [
+                'type' => 'text',
+                'text' => 'User question',
+            ],
+        ];
+
+        $assistantMessageData = [
+            'role' => 'assistant',
+            'content' => [
+                'type' => 'text',
+                'text' => 'Assistant response',
+            ],
+        ];
+
+        $data = [
+            'description' => $description,
+            'messages' => [$userMessageData, $assistantMessageData],
+        ];
+
+        $result = GetPromptResult::fromArray($data, $requestId);
+
+        // Verify basic properties
+        $this->assertEquals($requestId, $result->getRequestId());
+        $this->assertEquals($description, $result->getDescription());
+        $this->assertNull($result->getMeta());
+
+        // Verify messages
+        $messages = $result->getMessages();
+        $this->assertCount(2, $messages);
+
+        // First message (user)
+        $this->assertEquals(Role::USER, $messages[0]->getRole());
+        $content1 = $messages[0]->getUri();
+        $this->assertInstanceOf(TextContent::class, $content1);
+        $this->assertEquals('User question', $content1->getText());
+
+        // Second message (assistant)
+        $this->assertEquals(Role::ASSISTANT, $messages[1]->getRole());
+        $content2 = $messages[1]->getUri();
+        $this->assertInstanceOf(TextContent::class, $content2);
+        $this->assertEquals('Assistant response', $content2->getText());
+    }
+}

--- a/tests/Schema/PromptMessageTest.php
+++ b/tests/Schema/PromptMessageTest.php
@@ -1,0 +1,218 @@
+<?php
+
+namespace Swis\McpClient\Tests\Schema;
+
+use PHPUnit\Framework\TestCase;
+use Swis\McpClient\Exceptions\UnknownContentTypeException;
+use Swis\McpClient\Schema\Annotation;
+use Swis\McpClient\Schema\Content\EmbeddedResource;
+use Swis\McpClient\Schema\Content\ImageContent;
+use Swis\McpClient\Schema\Content\TextContent;
+use Swis\McpClient\Schema\PromptMessage;
+use Swis\McpClient\Schema\Resource\TextResourceContents;
+use Swis\McpClient\Schema\Role;
+
+class PromptMessageTest extends TestCase
+{
+    /**
+     * Test creating a PromptMessage instance with TextContent
+     */
+    public function testPromptMessageConstructionWithTextContent(): void
+    {
+        $textContent = new TextContent(
+            text: 'This is test text content'
+        );
+
+        $promptMessage = new PromptMessage(
+            role: Role::USER,
+            content: $textContent
+        );
+
+        $this->assertEquals(Role::USER, $promptMessage->getRole());
+        $this->assertSame($textContent, $promptMessage->getUri());
+    }
+
+    /**
+     * Test creating a PromptMessage instance with ImageContent
+     */
+    public function testPromptMessageConstructionWithImageContent(): void
+    {
+        $imageContent = new ImageContent(
+            data: 'base64_encoded_data',
+            mimeType: 'image/png'
+        );
+
+        $promptMessage = new PromptMessage(
+            role: Role::ASSISTANT,
+            content: $imageContent
+        );
+
+        $this->assertEquals(Role::ASSISTANT, $promptMessage->getRole());
+        $this->assertSame($imageContent, $promptMessage->getUri());
+    }
+
+    /**
+     * Test creating a PromptMessage instance with EmbeddedResource
+     */
+    public function testPromptMessageConstructionWithEmbeddedResource(): void
+    {
+        $resourceContent = new TextResourceContents(
+            text: 'This is embedded resource text',
+            uri: 'resource:123'
+        );
+
+        $embeddedResource = new EmbeddedResource(
+            resource: $resourceContent
+        );
+
+        $promptMessage = new PromptMessage(
+            role: Role::USER,
+            content: $embeddedResource
+        );
+
+        $this->assertEquals(Role::USER, $promptMessage->getRole());
+        $this->assertSame($embeddedResource, $promptMessage->getUri());
+    }
+
+    /**
+     * Test converting PromptMessage with TextContent to array
+     */
+    public function testPromptMessageToArrayWithTextContent(): void
+    {
+        $textContent = new TextContent(
+            text: 'This is test text content'
+        );
+
+        $promptMessage = new PromptMessage(
+            role: Role::USER,
+            content: $textContent
+        );
+
+        $array = $promptMessage->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertArrayHasKey('role', $array);
+        $this->assertArrayHasKey('content', $array);
+
+        $this->assertEquals('user', $array['role']);
+        $this->assertEquals($textContent->toArray(), $array['content']);
+    }
+
+    /**
+     * Test converting PromptMessage with ImageContent to array
+     */
+    public function testPromptMessageToArrayWithImageContent(): void
+    {
+        $imageContent = new ImageContent(
+            data: 'base64_encoded_data',
+            mimeType: 'image/png'
+        );
+
+        $promptMessage = new PromptMessage(
+            role: Role::ASSISTANT,
+            content: $imageContent
+        );
+
+        $array = $promptMessage->toArray();
+
+        $this->assertIsArray($array);
+        $this->assertArrayHasKey('role', $array);
+        $this->assertArrayHasKey('content', $array);
+
+        $this->assertEquals('assistant', $array['role']);
+        $this->assertEquals($imageContent->toArray(), $array['content']);
+    }
+
+    /**
+     * Test creating PromptMessage from array with TextContent
+     */
+    public function testPromptMessageFromArrayWithTextContent(): void
+    {
+        $array = [
+            'role' => 'user',
+            'content' => [
+                'type' => 'text',
+                'text' => 'This is test text content',
+            ],
+        ];
+
+        $promptMessage = PromptMessage::fromArray($array);
+
+        $this->assertEquals(Role::USER, $promptMessage->getRole());
+        $content = $promptMessage->getUri();
+        $this->assertInstanceOf(TextContent::class, $content);
+        $this->assertEquals('This is test text content', $content->getText());
+    }
+
+    /**
+     * Test creating PromptMessage from array with ImageContent
+     */
+    public function testPromptMessageFromArrayWithImageContent(): void
+    {
+        $array = [
+            'role' => 'assistant',
+            'content' => [
+                'type' => 'image',
+                'data' => 'base64_encoded_data',
+                'mimeType' => 'image/png',
+            ],
+        ];
+
+        $promptMessage = PromptMessage::fromArray($array);
+
+        $this->assertEquals(Role::ASSISTANT, $promptMessage->getRole());
+        $content = $promptMessage->getUri();
+        $this->assertInstanceOf(ImageContent::class, $content);
+        $this->assertEquals('base64_encoded_data', $content->getData());
+        $this->assertEquals('image/png', $content->getMimeType());
+    }
+
+    /**
+     * Test creating PromptMessage from array with unknown content type
+     */
+    public function testPromptMessageFromArrayWithUnknownContentType(): void
+    {
+        $array = [
+            'role' => 'user',
+            'content' => [
+                'type' => 'unknown',
+                'text' => 'This is test text content',
+            ],
+        ];
+
+        $this->expectException(UnknownContentTypeException::class);
+        PromptMessage::fromArray($array);
+    }
+
+    /**
+     * Test symmetry between toArray() and fromArray()
+     */
+    public function testSymmetryBetweenToArrayAndFromArray(): void
+    {
+        $textContent = new TextContent(
+            text: 'This is test text content',
+            annotations: new Annotation(
+                audience: [Role::ASSISTANT],
+                priority: 0.5
+            )
+        );
+
+        $original = new PromptMessage(
+            role: Role::USER,
+            content: $textContent
+        );
+
+        $array = $original->toArray();
+        $recreated = PromptMessage::fromArray($array);
+
+        $this->assertEquals($original->getRole(), $recreated->getRole());
+
+        $originalContent = $original->getUri();
+        $recreatedContent = $recreated->getUri();
+
+        $this->assertInstanceOf(TextContent::class, $recreatedContent);
+        if ($originalContent instanceof TextContent && $recreatedContent instanceof TextContent) {
+            $this->assertEquals($originalContent->getText(), $recreatedContent->getText());
+        }
+    }
+}


### PR DESCRIPTION
Fix: GetPromptResult schema compatibility issue #4 

This PR fixes an issue with GetPromptResult not being compatible with the actual schema. The key changes include:

- Added PromptMessage class to properly represent prompt messages in the MCP schema
- Updated GetPromptResult to use the new PromptMessage class
- Added tests for the GetPromptResult and PromptMessage classes