### PR TITLE
Remove unsupported roots capabilities

### DIFF
--- a/src/Requests/InitializeRequest.php
+++ b/src/Requests/InitializeRequest.php
@@ -21,7 +21,6 @@ class InitializeRequest extends BaseRequest
 
         // Set default capabilities
         $this->capabilities = array_merge([
-            'roots' => ['listChanged' => false],
             'sampling' => new \StdClass(),
         ], $capabilities);
 


### PR DESCRIPTION
`InitializeRequest` currently adds `roots` to the capabilities. However, it doesn't yet support the `roots/list` message. If an MCP Server attempts to make a request, it will time out / error.

Until `roots/list` is supported, this should be removed.

This is a higher priority as the way capabilities are initiated, it's not possible for downstream code to remove the declared support.