### PR TITLE
feat: Add support for custom headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,10 @@ use Swis\McpClient\Client;
 
 // Create client with SSE transporter
 $endpoint = 'https://your-mcp-server.com/sse';
-$client = Client::withSse($endpoint);
+$client = Client::withSse(
+    $endpoint,
+    headers: ['Authorization' => 'Bearer your-token']
+);
 
 // Connect to the server
 $client->connect(function($initResponse) {
@@ -92,7 +95,10 @@ use Swis\McpClient\Client;
 
 // Create client with StreamableHttp transporter
 $endpoint = 'https://your-mcp-server.com/';
-$client = Client::withStreamableHttp($endpoint);
+$client = Client::withStreamableHttp(
+    $endpoint,
+    headers: ['Authorization' => 'Bearer your-token']
+);
 
 // Connect to the server
 $client->connect();

--- a/examples/sse_transporter.php
+++ b/examples/sse_transporter.php
@@ -23,7 +23,11 @@ $logger = new ConsoleLogger();
 
 // Create client with SSE transporter and the logger
 $endpoint = 'https://glama.ai/mcp/instances/[example]/sse?'; // Replace with actual SSE endpoint
-$client = Client::withSse($endpoint, $logger);
+$client = Client::withSse(
+    $endpoint,
+    $logger,
+    headers: ['Authorization' => 'Bearer your-token']
+);
 
 $client->connect(function($initResponse) use ($logger) {
     $logger->info('Connected to server', [

--- a/examples/streamable_transporter.php
+++ b/examples/streamable_transporter.php
@@ -23,7 +23,11 @@ $logger = new ConsoleLogger();
 
 // Create client with Streamable HTTP transporter and the logger
 $endpoint = 'http://localhost:3000/mcp'; // Replace with actual SSE endpoint
-$client = Client::withStreamableHttp($endpoint, $logger);
+$client = Client::withStreamableHttp(
+    $endpoint,
+    $logger,
+    headers: ['Authorization' => 'Bearer your-token']
+);
 
 $client->connect(function($initResponse) use ($logger) {
     $logger->info('Connected to server', [

--- a/src/Client.php
+++ b/src/Client.php
@@ -262,14 +262,16 @@ class Client
      * @param string $endpoint The SSE endpoint URL
      * @param LoggerInterface|null $logger Optional logger
      * @param LoopInterface|null $loop Optional event loop
+     * @param array<string, string> $headers Custom headers to send with every request
      * @return self
      */
     public static function withSse(
         string $endpoint,
         ?LoggerInterface $logger = null,
-        ?LoopInterface $loop = null
+        ?LoopInterface $loop = null,
+        array $headers = []
     ): self {
-        $transporter = new SseTransporter($endpoint, $logger, $loop);
+        $transporter = new SseTransporter($endpoint, $logger, $loop, $headers);
         $eventDispatcher = new EventDispatcher();
 
         return new self($transporter, $eventDispatcher, $logger, $loop);
@@ -281,14 +283,16 @@ class Client
      * @param string $endpoint The SSE endpoint URL
      * @param LoggerInterface|null $logger Optional logger
      * @param LoopInterface|null $loop Optional event loop
+     * @param array<string, string> $headers Custom headers to send with every request
      * @return self
      */
     public static function withStreamableHttp(
         string $endpoint,
         ?LoggerInterface $logger = null,
-        ?LoopInterface $loop = null
+        ?LoopInterface $loop = null,
+        array $headers = []
     ): self {
-        $transporter = new StreamableHttpTransporter($endpoint, $logger, $loop);
+        $transporter = new StreamableHttpTransporter($endpoint, $logger, $loop, $headers);
         $eventDispatcher = new EventDispatcher();
 
         return new self($transporter, $eventDispatcher, $logger, $loop);

--- a/tests/Transporters/SseTransporterHeadersTest.php
+++ b/tests/Transporters/SseTransporterHeadersTest.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace Swis\McpClient\Tests\Transporters;
+
+use PHPUnit\Framework\TestCase;
+use Swis\McpClient\Transporters\SseTransporter;
+
+class SseTransporterHeadersTest extends TestCase
+{
+    public function testCustomHeadersAreIncludedInRequestAndSseConnectionHeaders(): void
+    {
+        $transporter = new class ('https://example.com/sse', null, null, ['Authorization' => 'Bearer test-token']) extends SseTransporter {
+            public function requestHeaders(): array
+            {
+                return $this->getRequestHeaders();
+            }
+
+            public function sseConnectionHeaders(): array
+            {
+                return $this->getSseConnectionHeaders();
+            }
+        };
+
+        $this->assertSame('Bearer test-token', $transporter->requestHeaders()['Authorization']);
+        $this->assertSame('Bearer test-token', $transporter->sseConnectionHeaders()['Authorization']);
+        $this->assertSame('application/json', $transporter->requestHeaders()['Content-Type']);
+        $this->assertSame('application/json', $transporter->requestHeaders()['Accept']);
+        $this->assertSame('text/event-stream', $transporter->sseConnectionHeaders()['Accept']);
+        $this->assertSame('no-cache', $transporter->sseConnectionHeaders()['Cache-Control']);
+    }
+
+    public function testProtocolHeadersOverrideConflictingCustomHeaders(): void
+    {
+        $transporter = new class (
+            'https://example.com/sse',
+            null,
+            null,
+            [
+                'Accept' => 'application/xml',
+                'Content-Type' => 'text/plain',
+                'Cache-Control' => 'max-age=3600',
+            ]
+        ) extends SseTransporter {
+            public function requestHeaders(): array
+            {
+                return $this->getDefaultHeaders();
+            }
+
+            public function sseConnectionHeaders(): array
+            {
+                return $this->getSseConnectionHeaders();
+            }
+        };
+
+        $this->assertSame('application/json', $transporter->requestHeaders()['Accept']);
+        $this->assertSame('application/json', $transporter->requestHeaders()['Content-Type']);
+        $this->assertSame('text/event-stream', $transporter->sseConnectionHeaders()['Accept']);
+        $this->assertSame('no-cache', $transporter->sseConnectionHeaders()['Cache-Control']);
+    }
+}


### PR DESCRIPTION
This PR adds support for passing custom HTTP headers that are sent with every request for both `SseTransporter` and `StreamableHttpTransporter`, and exposes this via `Client::withSse` and `Client::withStreamableHttp`.